### PR TITLE
Add `[monitor] mouse_passthrough` option to pass mouse events to sandboxed programs when using --monitor

### DIFF
--- a/app/airlock-cli/src/cli/cmd_start.rs
+++ b/app/airlock-cli/src/cli/cmd_start.rs
@@ -126,6 +126,7 @@ pub async fn main(
             max_tcp_connections: settings.monitor.buffers.tcp,
             scrollback: settings.monitor.buffers.scrollback,
             keys,
+            mouse_passthrough: settings.monitor.mouse_passthrough.into(),
         };
         run(
             cli_args,

--- a/app/airlock-cli/src/settings.rs
+++ b/app/airlock-cli/src/settings.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 pub use keys::KeyList;
+use serde::{Deserialize, Serialize};
 use smart_config::{ConfigRepository, ConfigSchema, DescribeConfig, DeserializeConfig, Json};
 
 use crate::config::de::format_error;
@@ -59,6 +60,44 @@ pub struct MonitorSettings {
     /// (`cancel = ["esc", "x"]`). Unset actions keep their defaults.
     #[config(default)]
     pub keys: BTreeMap<String, KeyList>,
+    /// How many of the Sandbox tab's mouse events reach the sandboxed
+    /// program. Defaults to `none` — the TUI keeps them all, so the
+    /// wheel scrolls its own scrollback. Set to `all` to hand them to
+    /// the sandboxed program instead, which is what makes scrolling work
+    /// inside a mouse-aware program like `claude`.
+    #[config(default)]
+    pub mouse_passthrough: MonitorMousePassthrough,
+}
+
+/// Value of `monitor.mouse_passthrough`. Lives here rather than in
+/// `airlock-monitor` because that crate has no `serde` dependency — the
+/// same split already used for `Policy` and `VaultStorageType`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MonitorMousePassthrough {
+    /// Nothing is passed through: the TUI owns the mouse everywhere,
+    /// wheel scrolls its scrollback, a click in the sandbox body enters
+    /// selection mode.
+    #[default]
+    None,
+    /// Every event on the Sandbox tab goes to the sandboxed program,
+    /// whenever it has mouse reporting enabled.
+    All,
+}
+
+impl smart_config::de::WellKnown for MonitorMousePassthrough {
+    type Deserializer =
+        smart_config::de::Serde<{ smart_config::metadata::BasicTypes::STRING.raw() }>;
+    const DE: Self::Deserializer = smart_config::de::Serde;
+}
+
+impl From<MonitorMousePassthrough> for airlock_monitor::MousePassthrough {
+    fn from(value: MonitorMousePassthrough) -> Self {
+        match value {
+            MonitorMousePassthrough::None => Self::None,
+            MonitorMousePassthrough::All => Self::All,
+        }
+    }
 }
 
 /// Settings under the `[monitor.buffers]` table. Defaults match the
@@ -221,6 +260,39 @@ mod tests {
     fn bad_vault_value_errors() {
         let dir = fresh_dir();
         std::fs::write(dir.join("settings.toml"), "vault.storage = \"typo\"\n").unwrap();
+        assert!(Settings::load_from(&dir).is_err());
+    }
+
+    #[test]
+    fn monitor_mouse_passthrough_defaults_to_none() {
+        let dir = fresh_dir();
+        let s = Settings::load_from(&dir).unwrap();
+        assert_eq!(s.monitor.mouse_passthrough, MonitorMousePassthrough::None);
+    }
+
+    #[test]
+    fn monitor_mouse_passthrough_parses_all() {
+        let dir = fresh_dir();
+        std::fs::write(
+            dir.join("settings.toml"),
+            "[monitor]\nmouse_passthrough = \"all\"\n",
+        )
+        .unwrap();
+        let s = Settings::load_from(&dir).unwrap();
+        assert_eq!(s.monitor.mouse_passthrough, MonitorMousePassthrough::All);
+    }
+
+    /// A typo must fail loudly at startup rather than silently leaving
+    /// the mouse with the TUI — the user would have no way to tell the
+    /// difference from "the setting doesn't work".
+    #[test]
+    fn bad_monitor_mouse_passthrough_value_errors() {
+        let dir = fresh_dir();
+        std::fs::write(
+            dir.join("settings.toml"),
+            "[monitor]\nmouse_passthrough = \"guest\"\n",
+        )
+        .unwrap();
         assert!(Settings::load_from(&dir).is_err());
     }
 }

--- a/app/airlock-monitor/src/lib.rs
+++ b/app/airlock-monitor/src/lib.rs
@@ -9,6 +9,7 @@
 mod app;
 pub mod input;
 pub mod keys;
+mod mouse;
 mod network_control;
 pub mod pty;
 mod settings;
@@ -22,8 +23,9 @@ use app::{App, Tab};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 pub use input::{TuiInputEvent, TuiStdin};
 pub use keys::{Action, KeyBindings};
+pub use mouse::MousePassthrough;
 pub use network_control::{NetworkControl, Policy};
-use pty::TuiTerminalSink;
+use pty::{MouseProtocolMode, TuiTerminalSink};
 use ratatui::DefaultTerminal;
 pub use settings::TuiSettings;
 pub use ui::TAB_BAR_HEIGHT;
@@ -402,7 +404,7 @@ fn handle_event(
             }
         }
         TuiEvent::Terminal(Event::Mouse(mouse)) => {
-            handle_mouse(mouse, app, sink, terminal, mouse_captured)?;
+            handle_mouse(mouse, app, sink, stdin_tx, terminal, mouse_captured)?;
         }
         TuiEvent::Terminal(Event::Resize(cols, rows)) => {
             let size = ratatui::layout::Rect::new(0, 0, cols, rows);
@@ -647,15 +649,57 @@ fn handle_monitor_action(
     }
 }
 
+/// Whether mouse events on the Sandbox tab currently belong to the
+/// sandboxed program rather than to the TUI.
+///
+/// Both the event router and the status line ask this, so the hint the
+/// user sees can never disagree with where the events actually go. It is
+/// derived fresh from settings + active tab + parser state, so there is
+/// nothing on `App` to keep in sync.
+///
+/// The guest's own mouse mode is part of the answer on purpose: that is
+/// what makes `mouse_passthrough = "all"` safe to leave on permanently.
+/// A program that never asked for mouse reporting would otherwise receive
+/// `\e[<64;10;5M` as literal keystrokes at its prompt, and the TUI's
+/// scrollback would become unreachable.
+fn guest_owns_mouse(app: &App, sink: &TuiTerminalSink) -> bool {
+    app.settings.mouse_passthrough == MousePassthrough::All
+        && app.active_tab == Tab::Sandbox
+        && sink.mouse_protocol_mode() != MouseProtocolMode::None
+}
+
 fn handle_mouse(
     mouse: MouseEvent,
     app: &mut App,
     sink: &mut TuiTerminalSink,
+    stdin_tx: &tokio::sync::mpsc::Sender<TuiInputEvent>,
     terminal: &mut DefaultTerminal,
     mouse_captured: &mut bool,
 ) -> anyhow::Result<()> {
     let size = terminal.size()?;
     let size = ratatui::layout::Rect::new(0, 0, size.width, size.height);
+
+    // Mouse routed to the sandboxed program: re-encode the event into its
+    // PTY instead of acting on it here. `encode` declines anything outside
+    // the body rect, so the tab bar keeps switching tabs.
+    //
+    // Scrolled-back views are excluded: on-screen rows no longer line up
+    // with guest rows there, so coordinates would be a lie. Falling
+    // through lets the wheel walk the view back down to the live screen,
+    // at which point forwarding resumes.
+    if guest_owns_mouse(app, sink)
+        && sink.scrollback() == 0
+        && let Some(bytes) = mouse::encode(
+            mouse,
+            sink.mouse_protocol_mode(),
+            sink.mouse_protocol_encoding(),
+            ui::body_area(size),
+        )
+    {
+        let _ = stdin_tx.blocking_send(TuiInputEvent::Data(bytes));
+        return Ok(());
+    }
+
     let tab_rects = ui::tab_header_rects(size, app);
 
     match mouse.kind {

--- a/app/airlock-monitor/src/mouse.rs
+++ b/app/airlock-monitor/src/mouse.rs
@@ -1,0 +1,466 @@
+//! Re-encoding host mouse events for the sandboxed program.
+//!
+//! The TUI owns the host terminal's mouse — `EnableMouseCapture` is what
+//! makes any event arrive at all — so a guest program that asked for mouse
+//! reporting never sees a click or a wheel tick. Merely dropping capture
+//! would hand the mouse to the host terminal emulator, not to the guest;
+//! the guest's own `\e[?1000h` never reaches the host terminal because its
+//! output is parsed by the embedded `vt100` and rendered as cells.
+//!
+//! So this module is the mirror image of `key_to_bytes`: it turns a
+//! crossterm [`MouseEvent`] back into the wire bytes the guest asked for.
+//! Pure and terminal-free, so every byte layout below is unit-testable.
+
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+
+use crate::pty::{MouseProtocolEncoding, MouseProtocolMode};
+
+/// How much of the mouse is passed through to the sandboxed program
+/// while the Sandbox tab is active.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MousePassthrough {
+    /// Nothing is passed through: the TUI handles every mouse event
+    /// itself, so the wheel scrolls its own scrollback and a click drops
+    /// capture for text selection.
+    #[default]
+    None,
+    /// Every event inside the sandbox body is re-encoded into the guest
+    /// PTY — but only while the guest actually has mouse reporting
+    /// enabled, so the TUI's own handling stays reachable at a plain
+    /// shell prompt.
+    All,
+}
+
+/// Xterm button codes. Wheel ticks are reported as button presses with
+/// bit 6 set; the horizontal wheel continues the same numbering.
+const BTN_RELEASE: u8 = 3;
+const BTN_WHEEL_UP: u8 = 64;
+const BTN_WHEEL_DOWN: u8 = 65;
+const BTN_WHEEL_LEFT: u8 = 66;
+const BTN_WHEEL_RIGHT: u8 = 67;
+
+/// Added to the button code to mark a report as motion rather than a
+/// state change.
+const MOTION: u8 = 32;
+
+const MOD_SHIFT: u8 = 4;
+const MOD_ALT: u8 = 8;
+const MOD_CTRL: u8 = 16;
+
+/// Largest coordinate the legacy encoding can express: each byte carries
+/// the value offset by 32, so 223 + 32 = 255 is the ceiling.
+const LEGACY_MAX_COORD: u16 = 223;
+
+/// What the guest is told happened, independent of wire format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Report {
+    /// A button went down, or the wheel turned.
+    Press(u8),
+    /// A button came up. Carries which one, because SGR can say — the
+    /// legacy encoding can't and reports a bare [`BTN_RELEASE`].
+    Release(u8),
+    /// The pointer crossed a cell boundary with a button held.
+    Drag(u8),
+    /// The pointer crossed a cell boundary with no button held.
+    Motion,
+}
+
+/// Encode a host mouse event for the guest PTY, or return `None` when it
+/// must not be forwarded.
+///
+/// `None` means one of: the guest has mouse reporting off, the event fell
+/// outside `body`, the guest's protocol mode doesn't want this class of
+/// event, or the position is beyond what the legacy encoding can express.
+/// In every case the caller should fall back to its own handling.
+///
+/// `body` is the on-screen rect the guest's grid is drawn into;
+/// coordinates are rebased onto it so the guest always sees its own
+/// 1-based grid regardless of where the body sits in the host terminal.
+pub fn encode(
+    event: MouseEvent,
+    mode: MouseProtocolMode,
+    encoding: MouseProtocolEncoding,
+    body: Rect,
+) -> Option<Vec<u8>> {
+    if mode == MouseProtocolMode::None {
+        return None;
+    }
+    let (col, row) = rebase(event.column, event.row, body)?;
+    let report = classify(event.kind);
+    if !wanted(mode, report) {
+        return None;
+    }
+    let mods = modifier_bits(event.modifiers);
+    match encoding {
+        MouseProtocolEncoding::Sgr => Some(encode_sgr(report, mods, col, row)),
+        // UTF-8 mode only diverges from the default encoding past column
+        // 223 — exactly where `encode_legacy` bails out anyway — so the
+        // two share one implementation.
+        MouseProtocolEncoding::Default | MouseProtocolEncoding::Utf8 => {
+            encode_legacy(report, mods, col, row)
+        }
+    }
+}
+
+/// Translate host-terminal coordinates into the guest's 1-based grid,
+/// rejecting anything outside the body rect.
+fn rebase(column: u16, row: u16, body: Rect) -> Option<(u16, u16)> {
+    if column < body.x || row < body.y {
+        return None;
+    }
+    let col = column - body.x;
+    let line = row - body.y;
+    if col >= body.width || line >= body.height {
+        return None;
+    }
+    Some((col + 1, line + 1))
+}
+
+fn classify(kind: MouseEventKind) -> Report {
+    match kind {
+        MouseEventKind::Down(b) => Report::Press(button_code(b)),
+        MouseEventKind::Up(b) => Report::Release(button_code(b)),
+        MouseEventKind::Drag(b) => Report::Drag(button_code(b)),
+        MouseEventKind::Moved => Report::Motion,
+        MouseEventKind::ScrollUp => Report::Press(BTN_WHEEL_UP),
+        MouseEventKind::ScrollDown => Report::Press(BTN_WHEEL_DOWN),
+        MouseEventKind::ScrollLeft => Report::Press(BTN_WHEEL_LEFT),
+        MouseEventKind::ScrollRight => Report::Press(BTN_WHEEL_RIGHT),
+    }
+}
+
+fn button_code(button: MouseButton) -> u8 {
+    match button {
+        MouseButton::Left => 0,
+        MouseButton::Middle => 1,
+        MouseButton::Right => 2,
+    }
+}
+
+/// Whether the guest's protocol mode asked for this class of event. A
+/// program that only requested presses must not be handed motion spam.
+fn wanted(mode: MouseProtocolMode, report: Report) -> bool {
+    match report {
+        // `mode == None` is rejected before we get here.
+        Report::Press(_) => true,
+        Report::Release(_) => matches!(
+            mode,
+            MouseProtocolMode::PressRelease
+                | MouseProtocolMode::ButtonMotion
+                | MouseProtocolMode::AnyMotion
+        ),
+        Report::Drag(_) => matches!(
+            mode,
+            MouseProtocolMode::ButtonMotion | MouseProtocolMode::AnyMotion
+        ),
+        Report::Motion => mode == MouseProtocolMode::AnyMotion,
+    }
+}
+
+fn modifier_bits(modifiers: KeyModifiers) -> u8 {
+    let mut bits = 0;
+    if modifiers.contains(KeyModifiers::SHIFT) {
+        bits |= MOD_SHIFT;
+    }
+    if modifiers.contains(KeyModifiers::ALT) {
+        bits |= MOD_ALT;
+    }
+    if modifiers.contains(KeyModifiers::CONTROL) {
+        bits |= MOD_CTRL;
+    }
+    bits
+}
+
+/// SGR (`\e[?1006h`): `CSI < Cb ; Cx ; Cy M`, with a final `m` for
+/// release. Decimal parameters, so there's no coordinate ceiling.
+fn encode_sgr(report: Report, mods: u8, col: u16, row: u16) -> Vec<u8> {
+    let (button, final_byte) = match report {
+        Report::Press(b) => (b, b'M'),
+        Report::Release(b) => (b, b'm'),
+        Report::Drag(b) => (b + MOTION, b'M'),
+        Report::Motion => (BTN_RELEASE + MOTION, b'M'),
+    };
+    let cb = button + mods;
+    let mut out = format!("\x1b[<{cb};{col};{row}").into_bytes();
+    out.push(final_byte);
+    out
+}
+
+/// Legacy (`\e[?1000h` without an encoding extension): `CSI M Cb Cx Cy`
+/// with every byte offset by 32. Release loses the button identity, and
+/// coordinates past 223 can't be expressed at all — those events are
+/// dropped rather than sent to the wrong cell.
+fn encode_legacy(report: Report, mods: u8, col: u16, row: u16) -> Option<Vec<u8>> {
+    if col > LEGACY_MAX_COORD || row > LEGACY_MAX_COORD {
+        return None;
+    }
+    let button = match report {
+        Report::Press(b) => b,
+        Report::Release(_) => BTN_RELEASE,
+        Report::Drag(b) => b + MOTION,
+        Report::Motion => BTN_RELEASE + MOTION,
+    };
+    let mut out = Vec::with_capacity(6);
+    out.extend_from_slice(b"\x1b[M");
+    out.push(32 + button + mods);
+    out.push(32 + col as u8);
+    out.push(32 + row as u8);
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Body rect with a non-zero origin, so every test also exercises
+    /// coordinate rebasing rather than an accidental identity mapping.
+    const BODY: Rect = Rect {
+        x: 2,
+        y: 1,
+        width: 40,
+        height: 20,
+    };
+
+    fn ev(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn with_mods(kind: MouseEventKind, modifiers: KeyModifiers) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: 2,
+            row: 1,
+            modifiers,
+        }
+    }
+
+    fn sgr(event: MouseEvent, mode: MouseProtocolMode) -> Option<String> {
+        encode(event, mode, MouseProtocolEncoding::Sgr, BODY)
+            .map(|b| String::from_utf8(b).expect("SGR output is ASCII"))
+    }
+
+    #[test]
+    fn sgr_press_release_and_drag() {
+        let down = MouseEventKind::Down(MouseButton::Left);
+        let up = MouseEventKind::Up(MouseButton::Left);
+        let drag = MouseEventKind::Drag(MouseButton::Left);
+        // (2,1) is the body origin, so the guest sees its own cell (1,1).
+        assert_eq!(
+            sgr(ev(down, 2, 1), MouseProtocolMode::PressRelease).as_deref(),
+            Some("\x1b[<0;1;1M")
+        );
+        // Release uses the final `m` and keeps the button identity.
+        assert_eq!(
+            sgr(ev(up, 2, 1), MouseProtocolMode::PressRelease).as_deref(),
+            Some("\x1b[<0;1;1m")
+        );
+        // Drag adds the motion bit (32) to the held button.
+        assert_eq!(
+            sgr(ev(drag, 4, 3), MouseProtocolMode::ButtonMotion).as_deref(),
+            Some("\x1b[<32;3;3M")
+        );
+    }
+
+    #[test]
+    fn sgr_middle_right_and_bare_motion() {
+        let middle = MouseEventKind::Down(MouseButton::Middle);
+        let right = MouseEventKind::Down(MouseButton::Right);
+        assert_eq!(
+            sgr(ev(middle, 2, 1), MouseProtocolMode::PressRelease).as_deref(),
+            Some("\x1b[<1;1;1M")
+        );
+        assert_eq!(
+            sgr(ev(right, 2, 1), MouseProtocolMode::PressRelease).as_deref(),
+            Some("\x1b[<2;1;1M")
+        );
+        // Bare motion is "no button" (3) plus the motion bit.
+        assert_eq!(
+            sgr(
+                ev(MouseEventKind::Moved, 2, 1),
+                MouseProtocolMode::AnyMotion
+            )
+            .as_deref(),
+            Some("\x1b[<35;1;1M")
+        );
+    }
+
+    #[test]
+    fn sgr_wheel_both_axes() {
+        for (kind, cb) in [
+            (MouseEventKind::ScrollUp, 64),
+            (MouseEventKind::ScrollDown, 65),
+            (MouseEventKind::ScrollLeft, 66),
+            (MouseEventKind::ScrollRight, 67),
+        ] {
+            assert_eq!(
+                sgr(ev(kind, 2, 1), MouseProtocolMode::PressRelease).as_deref(),
+                Some(format!("\x1b[<{cb};1;1M").as_str()),
+                "{kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn modifier_bits_fold_into_cb() {
+        let down = MouseEventKind::Down(MouseButton::Left);
+        for (modifiers, cb) in [
+            (KeyModifiers::SHIFT, 4),
+            (KeyModifiers::ALT, 8),
+            (KeyModifiers::CONTROL, 16),
+            (KeyModifiers::CONTROL | KeyModifiers::ALT, 24),
+            (
+                KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+                28,
+            ),
+        ] {
+            assert_eq!(
+                sgr(with_mods(down, modifiers), MouseProtocolMode::PressRelease).as_deref(),
+                Some(format!("\x1b[<{cb};1;1M").as_str()),
+                "{modifiers:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_byte_layout() {
+        let down = MouseEventKind::Down(MouseButton::Left);
+        let bytes = encode(
+            ev(down, 4, 3),
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Default,
+            BODY,
+        );
+        // Cell (3,3) of the guest grid: 32+0, 32+3, 32+3.
+        assert_eq!(bytes.as_deref(), Some(b"\x1b[M\x20\x23\x23".as_slice()));
+    }
+
+    /// The legacy encoding can't name the released button, so every
+    /// release collapses onto code 3.
+    #[test]
+    fn legacy_release_is_button_three() {
+        let up = MouseEventKind::Up(MouseButton::Right);
+        let bytes = encode(
+            ev(up, 2, 1),
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Default,
+            BODY,
+        );
+        assert_eq!(bytes.as_deref(), Some(b"\x1b[M\x23\x21\x21".as_slice()));
+    }
+
+    /// Past column 223 the legacy encoding would silently address the
+    /// wrong cell, so the event is dropped instead. SGR has no such limit.
+    #[test]
+    fn legacy_drops_unrepresentable_coordinates() {
+        let wide = Rect {
+            x: 0,
+            y: 0,
+            width: 300,
+            height: 300,
+        };
+        let down = ev(MouseEventKind::Down(MouseButton::Left), 250, 5);
+        assert_eq!(
+            encode(
+                down,
+                MouseProtocolMode::PressRelease,
+                MouseProtocolEncoding::Default,
+                wide
+            ),
+            None
+        );
+        assert!(
+            encode(
+                down,
+                MouseProtocolMode::PressRelease,
+                MouseProtocolEncoding::Sgr,
+                wide
+            )
+            .is_some()
+        );
+    }
+
+    /// UTF-8 mode is treated as the legacy encoding: identical below 224,
+    /// and above it we drop rather than guess.
+    #[test]
+    fn utf8_matches_legacy() {
+        let down = ev(MouseEventKind::Down(MouseButton::Left), 4, 3);
+        assert_eq!(
+            encode(
+                down,
+                MouseProtocolMode::PressRelease,
+                MouseProtocolEncoding::Utf8,
+                BODY
+            ),
+            encode(
+                down,
+                MouseProtocolMode::PressRelease,
+                MouseProtocolEncoding::Default,
+                BODY
+            )
+        );
+    }
+
+    #[test]
+    fn mode_filters_event_classes() {
+        let down = ev(MouseEventKind::Down(MouseButton::Left), 2, 1);
+        let up = ev(MouseEventKind::Up(MouseButton::Left), 2, 1);
+        let drag = ev(MouseEventKind::Drag(MouseButton::Left), 2, 1);
+        let moved = ev(MouseEventKind::Moved, 2, 1);
+        let wheel = ev(MouseEventKind::ScrollUp, 2, 1);
+
+        // `None` — the guest never asked; nothing is forwarded.
+        for e in [down, up, drag, moved, wheel] {
+            assert_eq!(sgr(e, MouseProtocolMode::None), None, "{:?}", e.kind);
+        }
+        // `Press` (DEC 9) — presses and wheel only.
+        assert!(sgr(down, MouseProtocolMode::Press).is_some());
+        assert!(sgr(wheel, MouseProtocolMode::Press).is_some());
+        assert_eq!(sgr(up, MouseProtocolMode::Press), None);
+        assert_eq!(sgr(drag, MouseProtocolMode::Press), None);
+        assert_eq!(sgr(moved, MouseProtocolMode::Press), None);
+        // `PressRelease` (DEC 1000) — adds button up.
+        assert!(sgr(up, MouseProtocolMode::PressRelease).is_some());
+        assert_eq!(sgr(drag, MouseProtocolMode::PressRelease), None);
+        assert_eq!(sgr(moved, MouseProtocolMode::PressRelease), None);
+        // `ButtonMotion` (DEC 1002) — adds drag but not bare motion.
+        assert!(sgr(drag, MouseProtocolMode::ButtonMotion).is_some());
+        assert_eq!(sgr(moved, MouseProtocolMode::ButtonMotion), None);
+        // `AnyMotion` (DEC 1003) — everything.
+        assert!(sgr(moved, MouseProtocolMode::AnyMotion).is_some());
+    }
+
+    #[test]
+    fn events_outside_the_body_are_dropped() {
+        let down = MouseEventKind::Down(MouseButton::Left);
+        for (col, row) in [
+            (1, 1),   // left of the body
+            (2, 0),   // above the body
+            (42, 5),  // right of the body (x 2 + width 40)
+            (5, 21),  // below the body (y 1 + height 20)
+            (200, 1), // far right
+        ] {
+            assert_eq!(
+                sgr(ev(down, col, row), MouseProtocolMode::PressRelease),
+                None,
+                "({col},{row}) is outside the body"
+            );
+        }
+        // The far corner of the body is inside, and maps to the guest's
+        // bottom-right cell.
+        assert_eq!(
+            sgr(ev(down, 41, 20), MouseProtocolMode::PressRelease).as_deref(),
+            Some("\x1b[<0;40;20M")
+        );
+    }
+
+    #[test]
+    fn passthrough_defaults_to_none() {
+        assert_eq!(MousePassthrough::default(), MousePassthrough::None);
+    }
+}

--- a/app/airlock-monitor/src/pty.rs
+++ b/app/airlock-monitor/src/pty.rs
@@ -3,6 +3,11 @@
 //! Process output (stdout/stderr) is fed into the parser, and the resulting
 //! screen cells are rendered to the ratatui buffer by the sandbox tab.
 
+/// The guest's mouse reporting state, as tracked by the parser. Re-exported
+/// so `crate::mouse` can talk about it without spreading `vt100` imports
+/// across the crate.
+pub use vt100::{MouseProtocolEncoding, MouseProtocolMode};
+
 /// Wraps a `vt100::Parser` to receive PTY output and expose screen state.
 pub struct TuiTerminalSink {
     parser: vt100::Parser,
@@ -19,6 +24,27 @@ impl TuiTerminalSink {
 
     pub fn screen(&self) -> &vt100::Screen {
         self.parser.screen()
+    }
+
+    /// Which xterm mouse protocol the guest has enabled, if any
+    /// (`\e[?9h`, `\e[?1000h`, `\e[?1002h`, `\e[?1003h`). `None` means the
+    /// guest never asked for mouse reporting, so forwarding events to it
+    /// would land as literal escape bytes at its prompt.
+    pub fn mouse_protocol_mode(&self) -> MouseProtocolMode {
+        self.parser.screen().mouse_protocol_mode()
+    }
+
+    /// How the guest wants mouse reports encoded — SGR (`\e[?1006h`),
+    /// UTF-8 (`\e[?1005h`), or the default single-byte form.
+    pub fn mouse_protocol_encoding(&self) -> MouseProtocolEncoding {
+        self.parser.screen().mouse_protocol_encoding()
+    }
+
+    /// How many rows the view is scrolled back from the live screen. Zero
+    /// means on-screen rows line up with the guest's own grid, which is a
+    /// precondition for forwarding mouse coordinates to it.
+    pub fn scrollback(&self) -> usize {
+        self.parser.screen().scrollback()
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) {

--- a/app/airlock-monitor/src/settings.rs
+++ b/app/airlock-monitor/src/settings.rs
@@ -2,6 +2,7 @@
 //! user config; defaults match what the values used to be hard-coded to.
 
 use crate::keys::KeyBindings;
+use crate::mouse::MousePassthrough;
 
 pub struct TuiSettings {
     /// Max HTTP request entries kept in the Monitor tab buffer. Older
@@ -15,6 +16,11 @@ pub struct TuiSettings {
     /// Key → action map consulted on every keystroke. Built once at
     /// startup from the user's `[monitor.keys]` config (or defaults).
     pub keys: KeyBindings,
+    /// How much of the mouse the Sandbox tab passes through. Defaults to
+    /// `None`, keeping every event in the TUI; `All` re-encodes them into
+    /// the guest PTY instead, so mouse wheel scrolling works inside the
+    /// sandboxed program.
+    pub mouse_passthrough: MousePassthrough,
 }
 
 impl Default for TuiSettings {
@@ -24,6 +30,7 @@ impl Default for TuiSettings {
             max_tcp_connections: 100,
             scrollback: 1000,
             keys: KeyBindings::defaults(),
+            mouse_passthrough: MousePassthrough::default(),
         }
     }
 }

--- a/app/airlock-monitor/src/ui.rs
+++ b/app/airlock-monitor/src/ui.rs
@@ -103,11 +103,13 @@ pub fn render(f: &mut Frame<'_>, app: &App, sink: &TuiTerminalSink) {
         }
     }
 
-    // Tab bar at the bottom
-    render_tab_bar(f, tab_area, app);
+    // Tab bar at the bottom. Whether the guest currently owns the mouse is
+    // recomputed every frame from settings + active tab + parser state, so
+    // the hint can't go stale the way a cached flag on `App` could.
+    render_tab_bar(f, tab_area, app, crate::guest_owns_mouse(app, sink));
 }
 
-fn render_tab_bar(f: &mut Frame<'_>, area: Rect, app: &App) {
+fn render_tab_bar(f: &mut Frame<'_>, area: Rect, app: &App, guest_owns_mouse: bool) {
     let sandbox_sel = app.active_tab == Tab::Sandbox;
     let network_sel = app.active_tab == Tab::Monitor;
 
@@ -161,14 +163,14 @@ fn render_tab_bar(f: &mut Frame<'_>, area: Rect, app: &App) {
         .render(tabs_row, f.buffer_mut());
 
     // Right-aligned status indicators on the same row.
-    let status = build_status_line(app);
+    let status = build_status_line(app, guest_owns_mouse);
     Paragraph::new(status)
         .style(bar_style)
         .alignment(Alignment::Right)
         .render(tabs_row, f.buffer_mut());
 }
 
-fn build_status_line(app: &App) -> Line<'static> {
+fn build_status_line(app: &App, guest_owns_mouse: bool) -> Line<'static> {
     let label = Style::default().fg(Color::Gray);
     let value = Style::default().fg(Color::DarkGray);
     let sep = Span::styled(" │ ", value);
@@ -180,9 +182,18 @@ fn build_status_line(app: &App) -> Line<'static> {
     let denied = app.monitor.network.request_denied;
 
     let mut spans = Vec::with_capacity(16);
+    // The two hints share one slot, and selection mode wins: while capture
+    // is released no mouse event reaches us at all, so nothing is being
+    // forwarded no matter what the guest asked for.
     if !app.mouse_captured {
         spans.push(Span::styled(
             "Selection mode — Ctrl+C to copy, Esc to exit",
+            Style::default().fg(Color::Yellow),
+        ));
+        spans.push(sep.clone());
+    } else if guest_owns_mouse {
+        spans.push(Span::styled(
+            "Mouse → sandbox",
             Style::default().fg(Color::Yellow),
         ));
         spans.push(sep.clone());

--- a/docs/manual/src/usage/monitor.md
+++ b/docs/manual/src/usage/monitor.md
@@ -104,8 +104,8 @@ Total and used bytes (reported the way `free` and `htop` do:
 
 ## Personal settings
 
-Buffer caps, terminal scrollback, and key bindings are personal
-preferences — they live in `~/.airlock/settings.toml`, not in the
+Buffer caps, terminal scrollback, key bindings, and mouse passthrough are
+personal preferences — they live in `~/.airlock/settings.toml`, not in the
 per-project `airlock.toml`. All fields default to the values used
 here, so there's nothing to set unless you want to change them.
 
@@ -191,6 +191,50 @@ Invalid key strings (unknown modifier, unknown key name) are reported
 up front when the sandbox starts; airlock refuses to launch the TUI
 rather than silently dropping a binding.
 
+### Mouse passthrough
+
+By default the TUI keeps every mouse event for itself, so the wheel
+scrolls the monitor's own scrollback and a click enters selection mode.
+That means a mouse-aware program running in the sandbox — `claude`, an
+editor, `htop` — never sees the wheel, and scrolling inside it does
+nothing.
+
+Set `mouse_passthrough = "all"` to hand those events to the sandboxed
+program instead:
+
+```toml
+[monitor]
+mouse_passthrough = "none"  # default; the TUI owns the mouse everywhere
+# mouse_passthrough = "all" # the sandboxed program owns it on the Sandbox tab
+```
+
+It's an enum rather than a boolean because mouse capture stays on in
+both modes — it has to, or no mouse events would reach airlock at all.
+What changes is where they go afterwards.
+
+Passthrough is deliberately narrow. Events are forwarded only when all
+of the following hold, and fall back to the TUI's own handling
+otherwise:
+
+| Situation                                   | Mouse goes to                                    |
+|---------------------------------------------|--------------------------------------------------|
+| Sandbox tab, program asked for the mouse     | the sandboxed program                            |
+| Sandbox tab, program didn't (a plain shell)  | TUI — wheel scrolls scrollback, click selects    |
+| Sandbox tab, scrolled back                   | TUI — the wheel walks the view back to the bottom |
+| Tab bar row (either tab)                     | TUI — tab switching                              |
+| Monitor tab                                  | TUI — policy dropdown, sub-tabs, details scroll  |
+
+The check against what the program asked for is what makes the setting
+safe to leave on permanently: a program that never enabled mouse
+reporting would otherwise see reports like `^[[<64;10;5M` arrive as
+literal keystrokes at its prompt, and the monitor's scrollback would
+become unreachable. The Monitor tab is never forwarded to — the guest
+isn't visible there, so its coordinates would be meaningless.
+
+While events are actually being passed through, the tab bar shows a
+`Mouse → sandbox` hint in the same slot as the `Selection mode` hint,
+so where the mouse is going is never a mystery.
+
 ## Selecting text
 
 Clicking inside the Sandbox tab releases mouse capture so the host
@@ -211,3 +255,11 @@ on the next press. The keys that end selection mode don't also do their
 usual job — `Ctrl+C` copies without interrupting whatever is running in
 the sandbox, and `Esc` doesn't close the details view. Press either a
 second time for that.
+
+With [`mouse_passthrough = "all"`](#mouse-passthrough), a click in the
+Sandbox tab belongs to the sandboxed program whenever that program has
+mouse reporting on, so it no longer enters selection mode. Most terminals
+still let you select natively while holding **Shift** (xterm, GNOME
+Terminal, Konsole, iTerm2) — that's the escape hatch. Selection mode
+keeps working as described above when the sandboxed program hasn't
+asked for the mouse, and in the Monitor tab's details view either way.


### PR DESCRIPTION
This is an example of how to solve https://github.com/milankinen/airlock/issues/11 - not necessarily a proposal for the solution since I think mouse forwarding should be the default.

Running `airlock start --monitor` left the mouse useless inside sandboxed TUI programs such as claude code - the monitor ate up the mouse events making eg. mouse scrolling impossible.

Set `mouse = "sandbox"` under `[monitor]` in ~/.airlock/settings.toml to turn this on; the default `"monitor"` keeps today's behaviour. Events only go to the sandboxed program when it has actually asked the terminal for mouse reporting, which is what makes the setting safe to leave on: at a plain shell prompt the wheel still scrolls the monitor's scrollback and a click still starts a text selection. The Monitor tab and the tab bar always keep the mouse, so mouse still works with the monitor TUI. A `Mouse → sandbox` hint in the tab bar shows when routing is live.